### PR TITLE
Add NVIDIA NemoClaw & OpenShell session

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ The group meets every 2 week on Tuesday Afternoon at 3-4:30pm. Contact Edwin if 
 |------|-------|------|
 |   17/02/2026   |    [OpenCode](https://opencode.ai/)      |   Edwin   |
 |   09/03/2026   |   Agent Presentation Practice Walkthrough    |   Shaun and Edwin    |
-| 17/03/2026 | [Agents of Chaos](https://arxiv.org/pdf/2602.20021) | Farhad
+| 17/03/2026 | [Agents of Chaos](https://arxiv.org/pdf/2602.20021) | Farhad |
+| 31/03/2026 | [NVIDIA NemoClaw](https://www.nvidia.com/en-gb/ai/nemoclaw/) & [OpenShell](https://github.com/NVIDIA/OpenShell) — Secure runtimes for autonomous agents | TBD |
 


### PR DESCRIPTION
## Summary

- Adds a new reading group session on **NVIDIA NemoClaw** and **NVIDIA OpenShell**, two technologies announced at GTC 2026 for securing autonomous AI agents
- Scheduled for **31 March 2026** (next slot after Agents of Chaos)
- Lead TBD

## Background

**OpenShell** is an open-source secure runtime (sandbox) for autonomous agents — providing kernel-level isolation, declarative YAML policies, and a privacy router to prevent data exfiltration.

**NemoClaw** is a plugin/stack that packages the OpenClaw agent together with OpenShell for single-command enterprise-ready deployment.

Together they address a timely question for the group: *how do we let autonomous agents act freely without compromising security or privacy?*

## Links

- [NVIDIA NemoClaw](https://www.nvidia.com/en-gb/ai/nemoclaw/)
- [NVIDIA OpenShell (GitHub)](https://github.com/NVIDIA/OpenShell)

## Test plan

- [ ] Date falls on a Tuesday and follows the fortnightly cadence
- [ ] Links render correctly in the schedule table
- [ ] Table formatting is consistent with existing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)