### PR TITLE
feat: add lychee offline link-check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,19 @@
+name: Link check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links (offline)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline **/*.md
+          fail: true


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/link-check.yml`) that runs `lychee --offline` against all Markdown files
- Triggers on pushes and PRs targeting `main`
- Uses the official `lycheeverse/lychee-action@v2` action
- Fails CI if any broken links are detected

## Test plan

- [ ] Confirm workflow appears under the Actions tab after merge
- [ ] Open a PR with a deliberately broken link (`[text](./nonexistent.md)`) and verify the check fails
- [ ] Verify the check passes on the current repo content

🤖 Generated with [Claude Code](https://claude.com/claude-code)